### PR TITLE
Fix spelling in live CLI

### DIFF
--- a/src/ffsplat/cli/live.py
+++ b/src/ffsplat/cli/live.py
@@ -259,7 +259,7 @@ class InteractiveConversionTool:
         shutil.copytree(self.scenes[scene_id].data_path, scene_path, dirs_exist_ok=True)
 
     def _save_encoding_params(self, scene_id):
-        print(f"Saving encoding paramters from scene {scene_id}...")
+        print(f"Saving encoding parameters from scene {scene_id}...")
         params_path = Path(self.viewer.results_path_input.value) / Path(f"scene_{scene_id}/encoding_params")
         if not os.path.exists(params_path):
             os.makedirs(params_path)


### PR DESCRIPTION
## Summary
- fix spelling of `parameters` in live CLI

## Testing
- `pre-commit run --files src/ffsplat/cli/live.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a4778fbc83208b95d9a55190ad2a